### PR TITLE
Resolved an issue preventing plugin from working correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ exports.register = function(app) {
 	var logger = app.lib.logger('projects reloader');
 
 	// start file watcher for reloading projects on change
-	var syncProject = function(filename, fileInfo) {
+	var addOrChangeProject = function(filename) {
 		var projectName = path.relative(
 			app.config.paths.projects,
 			path.dirname(filename)
@@ -18,23 +18,34 @@ exports.register = function(app) {
 			app.projects.unload({name: projectName});
 		}
 
-		// on add or change (info is falsy on unlink)
-		if (fileInfo) {
-			logger.log('Load project "' + projectName + '" on change');
-			app.projects.load({name: projectName}, function(err) {
-				if (err) {
-					return logger.error(
-						'Error during load project "' + projectName + '": ',
-						err.stack || err
-					);
-				}
-				logger.log(
-					'Project "' + projectName + '" loaded:',
-					JSON.stringify(app.projects.get(projectName), null, 4)
+		logger.log('Load project "' + projectName + '" on change');
+		app.projects.load({name: projectName}, function(err) {
+			if (err) {
+				return logger.error(
+					'Error during load project "' + projectName + '": ',
+					err.stack || err
 				);
-			});
+			}
+			logger.log(
+				'Project "' + projectName + '" loaded:',
+				JSON.stringify(app.projects.get(projectName), null, 4)
+			);
+		});
+	};	
+
+	var unlinkProject = function(filename) {
+		var projectName = path.relative(
+			app.config.paths.projects,
+			path.dirname(filename)
+		);
+
+		if (app.projects.get(projectName)) {
+			logger.log('Unload project: "' + projectName + '"');
+			app.projects.unload({name: projectName});
 		}
 	};
+
+
 
 	// NOTE: currently after add remove and then add same file events will
 	// not be emitted
@@ -42,9 +53,10 @@ exports.register = function(app) {
 		path.join(app.config.paths.projects, '*', 'config.*'),
 		{ignoreInitial: true, depth: 1}
 	);
-	watcher.on('add', syncProject);
-	watcher.on('change', syncProject);
-	watcher.on('unlink', syncProject);
+	watcher.on('add', addOrChangeProject);
+	watcher.on('change', addOrChangeProject);
+	watcher.on('unlink', unlinkProject);
+
 
 	watcher.on('error', function(err) {
 		logger.error('File watcher error occurred: ', err.stack || err);


### PR DESCRIPTION
The version of chokidar that is installed with `npm install` no longer passes an fs.stat object as a second parameter, so it was impossible for the plugin to determine the type of update event for the project, and in most cases would never reload a changed project. This pull request refactors the plugin a bit so it will work as intended.